### PR TITLE
problema identificador

### DIFF
--- a/analisador.lex
+++ b/analisador.lex
@@ -39,7 +39,9 @@ NUM     {digit}+
 WS      [ \t\r]+
 NL      \n
 COM_OP  "=="|"!="|"<"|"<="|">"|">="
+INVALID {digit}+({letter}|{digit})*
 LIT_STRING    \"([^\"\\\n]|\\[abfnrtv\"\'\\0])*\"
+
 
 %%
 
@@ -71,6 +73,7 @@ LIT_STRING    \"([^\"\\\n]|\\[abfnrtv\"\'\\0])*\"
 
 {WS}                ; /* Ignore spaces */
 
+{INVALID}           { fprintf(out, "<%d, ERROR, %s>\n", yylineno, yytext); return 0; }
 .                   { fprintf(out, "<%d, ERROR, %s>\n", yylineno, yytext); return 0; }
 
 %%


### PR DESCRIPTION
Tinha um problema no reconhecimento do token que iniciassem com numeros por exemplo:

```c
int main() {
    int 1ano = 5;

}
```

a análisador tava reconhendo 1 como NUM e ano como ID. Ele nunca chegava no erro '.'